### PR TITLE
Commands do not have an s on them

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ By default, all docs are present in this workflow but maybe you dont need all do
 
 ## Availables commands
 
-- cdocs:list = List all docs you can add in your workflow	
-- cdocs:add = Add a doc in your workflow, if you have already all docs, that command do nothing
-- cdocs:remove = Remove a doc in your workflow, if you haven't a doc in your workflow, that command do nothing
-- cdocs:addall = Add all docs available to your workflow
-- cdocs:nuke = Remove all docs in your workflow
-- cdocs:refresh = Refresh cache for a doc if specified or all if you want.
+- cdoc:list = List all docs you can add in your workflow	
+- cdoc:add = Add a doc in your workflow, if you have already all docs, that command do nothing
+- cdoc:remove = Remove a doc in your workflow, if you haven't a doc in your workflow, that command do nothing
+- cdoc:addall = Add all docs available to your workflow
+- cdoc:nuke = Remove all docs in your workflow
+- cdoc:refresh = Refresh cache for a doc if specified or all if you want.
 
 # Install
 ```sh


### PR DESCRIPTION
I think the docs have a mistake in saying that the commands are cdocs with an **s**

cdoc:

![](http://wes.io/XpWG/content)

cdocs:

![](http://wes.io/Xp7a/content)
