### PR TITLE
Add hint about adding documentations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Alfred workflow for the amazing [devdocs.io](http://devdocs.io/) documentations.
 # Install
 Use the packaged workflow [DevDocs.alfredworkflow](https://github.com/packal/repository/raw/master/com.yannickglt.alfred2.devdocs/devdocs.alfredworkflow) from packal.
 
+## Add docs
+Now add some documentations to your workflow like this:
+
+```
+docs:add javascript
+```
+
 # How to
 ## Find in a specific documentation
 Keywords exist for each documentation supported by DevDocs.


### PR DESCRIPTION
For me it feels like the workflow comes with all docs out of the box so you can just install the workflow and start searching. I looked first in the readme (nothing found) and than in to issues (closed ones) to find the solution. thankfully someone else had this problem as well …