### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/src/scripts/devdocs.php
+++ b/src/scripts/devdocs.php
@@ -79,7 +79,7 @@ class DevDocs {
 
     $query = strtolower($query);
     $data = json_decode(file_get_contents(self::$cacheDirectory . $documentation . '.json'));
-    if ($data === NULL) {
+    if ($data === null) {
       unlink(self::$cacheDirectory . $documentation . '.json');
     }
 

--- a/src/scripts/workflows.php
+++ b/src/scripts/workflows.php
@@ -171,7 +171,7 @@ class Workflows {
   public function toxml($a = null, $format = 'array') {
 
     if ($format == 'json'):
-      $a = json_decode($a, TRUE);
+      $a = json_decode($a, true);
     endif;
 
     if (is_null($a) && !empty($this->results)):


### PR DESCRIPTION
Hi, I've changed some PHP keywords to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!