### PR TITLE
Add options to enable integration with devdocs desktop

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -834,11 +834,11 @@
     <key>variables</key>
     <dict>
       <key>BASE_URL</key>
-      <string>devdocs://search/</string>
+      <string></string>
       <key>CACHE_LIFE</key>
-      <string>-1</string>
+      <string></string>
       <key>TEMPLATE</key>
-      <string>$baseUrl$docalt%20$name</string>
+      <string></string>
     </dict>
     <key>version</key>
     <string></string>

--- a/src/info.plist
+++ b/src/info.plist
@@ -17,6 +17,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>addalltaskkeyword</key>
@@ -28,6 +30,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>addtask</key>
@@ -39,6 +43,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>aliastask</key>
@@ -50,17 +56,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
-        </dict>
-      </array>
-      <key>unaliastask</key>
-      <array>
-        <dict>
-          <key>destinationuid</key>
-          <string>dotaskbasedoncommand</string>
-          <key>modifiers</key>
-          <integer>0</integer>
-          <key>modifiersubtext</key>
-          <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>doc</key>
@@ -85,6 +82,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>nuketask</key>
@@ -96,6 +95,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>nuketaskkeyword</key>
@@ -107,6 +108,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>refreshtask</key>
@@ -118,6 +121,8 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
       <key>removetask</key>
@@ -129,6 +134,34 @@
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
+          <key>vitoclose</key>
+          <false/>
+        </dict>
+      </array>
+      <key>ruby~2.6</key>
+      <array>
+        <dict>
+          <key>destinationuid</key>
+          <string>output</string>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false/>
+        </dict>
+      </array>
+      <key>unaliastask</key>
+      <array>
+        <dict>
+          <key>destinationuid</key>
+          <string>dotaskbasedoncommand</string>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false/>
         </dict>
       </array>
     </dict>
@@ -145,16 +178,33 @@
       <dict>
         <key>config</key>
         <dict>
+          <key>browser</key>
+          <string></string>
+          <key>spaces</key>
+          <string></string>
+          <key>url</key>
+          <string>{query}</string>
+          <key>utf8</key>
+          <true/>
+        </dict>
+        <key>type</key>
+        <string>alfred.workflow.action.openurl</string>
+        <key>uid</key>
+        <string>output</string>
+        <key>version</key>
+        <integer>1</integer>
+      </dict>
+      <dict>
+        <key>config</key>
+        <dict>
           <key>lastpathcomponent</key>
           <false/>
           <key>onlyshowifquerypopulated</key>
           <true/>
-          <key>output</key>
-          <integer>0</integer>
           <key>removeextension</key>
           <false/>
-          <key>sticky</key>
-          <false/>
+          <key>text</key>
+          <string></string>
           <key>title</key>
           <string>{query}</string>
         </dict>
@@ -163,11 +213,19 @@
         <key>uid</key>
         <string>shownotificationwhencomplete</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>1</integer>
       </dict>
       <dict>
         <key>config</key>
         <dict>
+          <key>alfredfiltersresults</key>
+          <false/>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
           <key>argumenttype</key>
           <integer>0</integer>
           <key>escaping</key>
@@ -185,9 +243,11 @@
           <key>runningsubtext</key>
           <string>Searching for "{query}"</string>
           <key>script</key>
-          <string>$query = "{query}";
-            require_once("scripts/devdocs.php");
-          </string>
+          <string>$query = "{query}"; require_once("scripts/devdocs.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
           <key>subtext</key>
           <string>Search for "{query}"</string>
           <key>title</key>
@@ -202,32 +262,19 @@
         <key>uid</key>
         <string>doc</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>3</integer>
       </dict>
       <dict>
         <key>config</key>
         <dict>
-          <key>concurrently</key>
+          <key>alfredfiltersresults</key>
           <false/>
-          <key>escaping</key>
-          <integer>126</integer>
-          <key>script</key>
-          <string>$query = "{query}";
-            require_once("scripts/conf.php");
-          </string>
-          <key>type</key>
-          <integer>1</integer>
-        </dict>
-        <key>type</key>
-        <string>alfred.workflow.action.script</string>
-        <key>uid</key>
-        <string>dotaskbasedoncommand</string>
-        <key>version</key>
-        <integer>0</integer>
-      </dict>
-      <dict>
-        <key>config</key>
-        <dict>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
           <key>argumenttype</key>
           <integer>1</integer>
           <key>escaping</key>
@@ -242,10 +289,16 @@
           <integer>0</integer>
           <key>queuemode</key>
           <integer>1</integer>
+          <key>runningsubtext</key>
+          <string></string>
           <key>script</key>
-          <string>$query = "selectAdd {query}";
-            require_once("scripts/conf.php");
-          </string>
+          <string>$query = "selectAdd {query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
           <key>title</key>
           <string>Add a doc on DevDocs workflow</string>
           <key>type</key>
@@ -258,81 +311,19 @@
         <key>uid</key>
         <string>addtask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>3</integer>
       </dict>
       <dict>
         <key>config</key>
         <dict>
-          <key>argumenttype</key>
-          <integer>0</integer>
-          <key>escaping</key>
-          <integer>118</integer>
-          <key>keyword</key>
-          <string>cdoc:alias</string>
-          <key>queuedelaycustom</key>
-          <integer>1</integer>
-          <key>queuedelayimmediatelyinitially</key>
+          <key>alfredfiltersresults</key>
           <false/>
-          <key>queuedelaymode</key>
+          <key>alfredfiltersresultsmatchmode</key>
           <integer>0</integer>
-          <key>queuemode</key>
-          <integer>1</integer>
-          <key>script</key>
-          <string>$query = "selectAlias {query}";
-            require_once("scripts/conf.php");
-          </string>
-          <key>title</key>
-          <string>Create an alias for a documentation</string>
-          <key>type</key>
-          <integer>1</integer>
-          <key>withspace</key>
-          <true/>
-        </dict>
-        <key>type</key>
-        <string>alfred.workflow.input.scriptfilter</string>
-        <key>uid</key>
-        <string>aliastask</string>
-        <key>version</key>
-        <integer>0</integer>
-      </dict>
-      <dict>
-        <key>config</key>
-        <dict>
-          <key>argumenttype</key>
-          <integer>1</integer>
-          <key>escaping</key>
-          <integer>118</integer>
-          <key>keyword</key>
-          <string>cdoc:unalias</string>
-          <key>queuedelaycustom</key>
-          <integer>1</integer>
-          <key>queuedelayimmediatelyinitially</key>
+          <key>argumenttreatemptyqueryasnil</key>
           <false/>
-          <key>queuedelaymode</key>
+          <key>argumenttrimmode</key>
           <integer>0</integer>
-          <key>queuemode</key>
-          <integer>1</integer>
-          <key>script</key>
-          <string>$query = "selectUnalias {query}";
-            require_once("scripts/conf.php");
-          </string>
-          <key>title</key>
-          <string>Remove an existing alias of a documentation</string>
-          <key>type</key>
-          <integer>1</integer>
-          <key>withspace</key>
-          <true/>
-        </dict>
-        <key>type</key>
-        <string>alfred.workflow.input.scriptfilter</string>
-        <key>uid</key>
-        <string>unaliastask</string>
-        <key>version</key>
-        <integer>0</integer>
-      </dict>
-      <dict>
-        <key>config</key>
-        <dict>
           <key>argumenttype</key>
           <integer>1</integer>
           <key>escaping</key>
@@ -347,10 +338,16 @@
           <integer>0</integer>
           <key>queuemode</key>
           <integer>1</integer>
+          <key>runningsubtext</key>
+          <string></string>
           <key>script</key>
-          <string>$query = "selectRemove {query}";
-            require_once("scripts/conf.php");
-          </string>
+          <string>$query = "selectRemove {query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
           <key>title</key>
           <string>Remove a doc on DevDocs workflow</string>
           <key>type</key>
@@ -363,11 +360,42 @@
         <key>uid</key>
         <string>removetask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>3</integer>
       </dict>
       <dict>
         <key>config</key>
         <dict>
+          <key>concurrently</key>
+          <false/>
+          <key>escaping</key>
+          <integer>126</integer>
+          <key>script</key>
+          <string>$query = "{query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>type</key>
+          <integer>1</integer>
+        </dict>
+        <key>type</key>
+        <string>alfred.workflow.action.script</string>
+        <key>uid</key>
+        <string>dotaskbasedoncommand</string>
+        <key>version</key>
+        <integer>2</integer>
+      </dict>
+      <dict>
+        <key>config</key>
+        <dict>
+          <key>alfredfiltersresults</key>
+          <false/>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
           <key>argumenttype</key>
           <integer>1</integer>
           <key>escaping</key>
@@ -382,10 +410,16 @@
           <integer>0</integer>
           <key>queuemode</key>
           <integer>1</integer>
+          <key>runningsubtext</key>
+          <string></string>
           <key>script</key>
-          <string>$query = "selectRefresh {query}";
-            require_once("scripts/conf.php");
-          </string>
+          <string>$query = "selectRefresh {query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
           <key>title</key>
           <string>Refresh docs on DevDocs workflow</string>
           <key>type</key>
@@ -398,11 +432,19 @@
         <key>uid</key>
         <string>refreshtask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>3</integer>
       </dict>
       <dict>
         <key>config</key>
         <dict>
+          <key>alfredfiltersresults</key>
+          <false/>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
           <key>argumenttype</key>
           <integer>1</integer>
           <key>escaping</key>
@@ -417,10 +459,16 @@
           <integer>0</integer>
           <key>queuemode</key>
           <integer>1</integer>
+          <key>runningsubtext</key>
+          <string></string>
           <key>script</key>
-          <string>$query = "list {query}";
-            require_once("scripts/conf.php");
-          </string>
+          <string>$query = "list {query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
           <key>title</key>
           <string>List available docs on DevDocs workflow</string>
           <key>type</key>
@@ -433,7 +481,7 @@
         <key>uid</key>
         <string>listtask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>3</integer>
       </dict>
       <dict>
         <key>config</key>
@@ -442,6 +490,8 @@
           <integer>2</integer>
           <key>keyword</key>
           <string>cdoc:all</string>
+          <key>subtext</key>
+          <string></string>
           <key>text</key>
           <string>Add all available docs on DevDocs workflow</string>
           <key>withspace</key>
@@ -452,7 +502,7 @@
         <key>uid</key>
         <string>addalltaskkeyword</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>1</integer>
       </dict>
       <dict>
         <key>config</key>
@@ -462,9 +512,11 @@
           <key>escaping</key>
           <integer>118</integer>
           <key>script</key>
-          <string>$query = "addAll";
-            require_once("scripts/conf.php");
-          </string>
+          <string>$query = "addAll"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
           <key>type</key>
           <integer>1</integer>
         </dict>
@@ -473,7 +525,7 @@
         <key>uid</key>
         <string>addalltask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>2</integer>
       </dict>
       <dict>
         <key>config</key>
@@ -482,6 +534,8 @@
           <integer>2</integer>
           <key>keyword</key>
           <string>cdoc:nuke</string>
+          <key>subtext</key>
+          <string></string>
           <key>text</key>
           <string>Remove all docs on your DevDocs workflow</string>
           <key>withspace</key>
@@ -492,7 +546,7 @@
         <key>uid</key>
         <string>nuketaskkeyword</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>1</integer>
       </dict>
       <dict>
         <key>config</key>
@@ -502,9 +556,11 @@
           <key>escaping</key>
           <integer>118</integer>
           <key>script</key>
-          <string>$query = "nuke";
-            require_once("scripts/conf.php");
-          </string>
+          <string>$query = "nuke"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
           <key>type</key>
           <integer>1</integer>
         </dict>
@@ -513,99 +569,279 @@
         <key>uid</key>
         <string>nuketask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>2</integer>
       </dict>
       <dict>
         <key>config</key>
         <dict>
-          <key>plusspaces</key>
+          <key>alfredfiltersresults</key>
           <false/>
-          <key>url</key>
-          <string>{query}</string>
-          <key>utf8</key>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
+          <key>argumenttype</key>
+          <integer>0</integer>
+          <key>escaping</key>
+          <integer>118</integer>
+          <key>keyword</key>
+          <string>cdoc:alias</string>
+          <key>queuedelaycustom</key>
+          <integer>1</integer>
+          <key>queuedelayimmediatelyinitially</key>
+          <false/>
+          <key>queuedelaymode</key>
+          <integer>0</integer>
+          <key>queuemode</key>
+          <integer>1</integer>
+          <key>runningsubtext</key>
+          <string></string>
+          <key>script</key>
+          <string>$query = "selectAlias {query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
+          <key>title</key>
+          <string>Create an alias for a documentation</string>
+          <key>type</key>
+          <integer>1</integer>
+          <key>withspace</key>
           <true/>
         </dict>
         <key>type</key>
-        <string>alfred.workflow.action.openurl</string>
+        <string>alfred.workflow.input.scriptfilter</string>
         <key>uid</key>
-        <string>output</string>
+        <string>aliastask</string>
         <key>version</key>
-        <integer>0</integer>
+        <integer>3</integer>
+      </dict>
+      <dict>
+        <key>config</key>
+        <dict>
+          <key>alfredfiltersresults</key>
+          <false/>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
+          <key>argumenttype</key>
+          <integer>1</integer>
+          <key>escaping</key>
+          <integer>118</integer>
+          <key>keyword</key>
+          <string>cdoc:unalias</string>
+          <key>queuedelaycustom</key>
+          <integer>1</integer>
+          <key>queuedelayimmediatelyinitially</key>
+          <false/>
+          <key>queuedelaymode</key>
+          <integer>0</integer>
+          <key>queuemode</key>
+          <integer>1</integer>
+          <key>runningsubtext</key>
+          <string></string>
+          <key>script</key>
+          <string>$query = "selectUnalias {query}"; require_once("scripts/conf.php");</string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
+          <key>title</key>
+          <string>Remove an existing alias of a documentation</string>
+          <key>type</key>
+          <integer>1</integer>
+          <key>withspace</key>
+          <true/>
+        </dict>
+        <key>type</key>
+        <string>alfred.workflow.input.scriptfilter</string>
+        <key>uid</key>
+        <string>unaliastask</string>
+        <key>version</key>
+        <integer>3</integer>
+      </dict>
+      <dict>
+        <key>config</key>
+        <dict>
+          <key>alfredfiltersresults</key>
+          <false/>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <false/>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
+          <key>argumenttype</key>
+          <integer>1</integer>
+          <key>escaping</key>
+          <integer>118</integer>
+          <key>keyword</key>
+          <string>ruby~2.6</string>
+          <key>queuedelaycustom</key>
+          <integer>1</integer>
+          <key>queuedelayimmediatelyinitially</key>
+          <false/>
+          <key>queuedelaymode</key>
+          <integer>0</integer>
+          <key>queuemode</key>
+          <integer>1</integer>
+          <key>runningsubtext</key>
+          <string>Searching for "{query}"</string>
+          <key>script</key>
+          <string>$query = "{query}"; $documentation = 'ruby~2.6';
+        require_once("scripts/devdocs.php");
+        </string>
+          <key>scriptargtype</key>
+          <integer>0</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string>Search for Ruby 2.6 "{query}"</string>
+          <key>title</key>
+          <string>DevDocs - Ruby 2.6</string>
+          <key>type</key>
+          <integer>1</integer>
+          <key>withspace</key>
+          <true/>
+        </dict>
+        <key>type</key>
+        <string>alfred.workflow.input.scriptfilter</string>
+        <key>uid</key>
+        <string>ruby~2.6</string>
+        <key>version</key>
+        <integer>3</integer>
       </dict>
     </array>
+    <key>readme</key>
+    <string></string>
     <key>uidata</key>
     <dict>
       <key>addalltask</key>
       <dict>
+        <key>xpos</key>
+        <integer>500</integer>
         <key>ypos</key>
         <real>510</real>
       </dict>
       <key>addalltaskkeyword</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>510</real>
       </dict>
       <key>addtask</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>110</real>
       </dict>
       <key>aliastask</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>710</real>
       </dict>
-      <key>unaliastask</key>
-      <dict>
-        <key>ypos</key>
-        <real>810</real>
-      </dict>
       <key>doc</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>10</real>
       </dict>
       <key>dotaskbasedoncommand</key>
       <dict>
+        <key>xpos</key>
+        <integer>505</integer>
         <key>ypos</key>
-        <real>110</real>
+        <integer>280</integer>
       </dict>
       <key>listtask</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>410</real>
       </dict>
       <key>nuketask</key>
       <dict>
+        <key>xpos</key>
+        <integer>500</integer>
         <key>ypos</key>
         <real>610</real>
       </dict>
       <key>nuketaskkeyword</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>610</real>
       </dict>
       <key>output</key>
       <dict>
+        <key>xpos</key>
+        <integer>500</integer>
         <key>ypos</key>
         <real>10</real>
       </dict>
       <key>refreshtask</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>310</real>
       </dict>
       <key>removetask</key>
       <dict>
+        <key>xpos</key>
+        <integer>300</integer>
         <key>ypos</key>
         <real>210</real>
       </dict>
+      <key>ruby~2.6</key>
+      <dict>
+        <key>xpos</key>
+        <integer>300</integer>
+        <key>ypos</key>
+        <real>930</real>
+      </dict>
       <key>shownotificationwhencomplete</key>
       <dict>
+        <key>xpos</key>
+        <integer>700</integer>
         <key>ypos</key>
         <real>10</real>
       </dict>
+      <key>unaliastask</key>
+      <dict>
+        <key>xpos</key>
+        <integer>300</integer>
+        <key>ypos</key>
+        <real>810</real>
+      </dict>
     </dict>
+    <key>variables</key>
+    <dict>
+      <key>BASE_URL</key>
+      <string>devdocs://search/</string>
+      <key>CACHE_LIFE</key>
+      <string>-1</string>
+      <key>TEMPLATE</key>
+      <string>$baseUrl$docalt%20$name</string>
+    </dict>
+    <key>version</key>
+    <string></string>
     <key>webaddress</key>
     <string>https://github.com/yannickglt/alfred-devdocs</string>
   </dict>


### PR DESCRIPTION
Parameterize some code and add the following workflow options:

BASE_URL (leave empty to use default: `https://devdocs.io/`)
CACHE_LIFE (day as unit, leave empty to use default `7`)
TEMPLATE (leave empty to use default: `$baseUrl$documentation/$path`)

The options will make the workflow more friendly for offline use, for example:

1. For self-hostet server, replace BASE_URL
2. For [DevDocs Desktop](https://github.com/egoist/devdocs-desktop), set:
  BASE_URL:  `devdocs://search/`
  CACHE_LIFE:   `-1`
  TEMPLATE:  `$baseUrl$docalt%20$name`

In the 2nd case, the workflow uses devdocs://search/xx to redirect to devdocs desktop. Given a infinite cache life (-1 to represent), the user can fully depend on the offline app after loading indices from https://docs.devdocs.io.

This pull request will not change the behavior of the workflow unless a user sets the 3 variables mentioned above.