### PR TITLE
support php versions above 7.4

### DIFF
--- a/src/scripts/vendor/rodneyrehm/plist/classes/CFPropertyList/CFBinaryPropertyList.php
+++ b/src/scripts/vendor/rodneyrehm/plist/classes/CFPropertyList/CFBinaryPropertyList.php
@@ -784,7 +784,7 @@ abstract class CFBinaryPropertyList {
    */
   protected static function binaryStrlen($val) {
     for($i=0;$i<strlen($val);++$i) {
-      if(ord($val{$i}) >= 128) {
+      if(ord($val[$i]) >= 128) {
         $val = self::convertCharset($val, 'UTF-8', 'UTF-16BE');
         return strlen($val);
       }
@@ -807,7 +807,7 @@ abstract class CFBinaryPropertyList {
       $utf16 = false;
 
       for($i=0;$i<strlen($val);++$i) {
-        if(ord($val{$i}) >= 128) {
+        if(ord($val[$i]) >= 128) {
           $utf16 = true;
           break;
         }


### PR DESCRIPTION
Hi
It looks like after PHP was upgraded (or installed on a new mac using `brew php install`) plugin stopped working 
and exception was thrown with the following error message:
```Array and string offset access syntax with curly braces is no longer supported```

I've checked it out and it looks like the syntax of php was changed many years ago 
so I've adjusted the file that held this issue (by replacing the `eval{$i}` to `eval[$i]` and presto, it works! 

